### PR TITLE
fix: returns focus to the last focused window, even a non-Unity one

### DIFF
--- a/i3unityfix/i3unityfix.py
+++ b/i3unityfix/i3unityfix.py
@@ -33,15 +33,11 @@ class I3UnityFix(object):
             
         workspace = event.current
 
-        # Same screen check
-        if event.old.rect.x == event.current.rect.x:
+        if event.old.rect.x == event.current.rect.x: # Same screen check
             windows = list(workspace.leaves())
             windows = list(filter(window_is_unity, windows))
 
-            previously_focused_window = None
-
-            if len(windows) > 1:
-                previously_focused_window = find_focused_window(workspace)
+            previously_focused_window = find_focused_window(workspace)
 
             for window in windows:
                 window.command("fullscreen enable")
@@ -49,11 +45,9 @@ class I3UnityFix(object):
                 self.keyboard.press(Key.home)
                 self.keyboard.release(Key.home)
 
-            if previously_focused_window is not None and previously_focused_window.window_class == "Unity":
-                previously_focused_window.command("focus")
-        
-	
+            previously_focused_window.command("focus")
             
+
 def main():
     i3 = Connection()
     handler = I3UnityFix()


### PR DESCRIPTION
This PR aims to fix a little bug of window focusing due to the script.

Let's say you have a workspace with a few windows opened on it, including Unity. If you went to another workspace and then back to this first one, the script would **force** the focus on Unity, even if you left it with a focus on something else (i.e, Visual Studio Code).

This little fix removes some conditions, so it can give the focus back to any last focused window on the Unity workspace, even if it wasn't a Unity one.

The i3 fix still works for me after this little change.