### PR TITLE
Don't crash on suspend

### DIFF
--- a/i3unityfix/i3unityfix.py
+++ b/i3unityfix/i3unityfix.py
@@ -33,7 +33,7 @@ class I3UnityFix(object):
         workspace = event.current
 
         # Same screen check
-        if event.old.rect.x == event.current.rect.x:
+        if event.old is not None and event.old.rect.x == event.current.rect.x:
             self.fix_if_necessary(workspace)
 
     def get_current_workspace(self):


### PR DESCRIPTION
When resuming from `systemctl suspend`, the script crashes with the following trace: 
```
Traceback (most recent call last):
  File "/home/user/github/i3-unity-fix/i3unityfix/i3unityfix.py", line 77, in <module>
    main()
    ~~~~^^
  File "/home/user/github/i3-unity-fix/i3unityfix/i3unityfix.py", line 74, in main
    i3.main()
    ~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 514, in main
    raise loop_exception
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 497, in main
    while not self._event_socket_poll():
              ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 477, in _event_socket_poll
    raise e
  File "/usr/lib/python3.13/site-packages/i3ipc/connection.py", line 474, in _event_socket_poll
    self._pubsub.emit(event_name, event)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/i3ipc/_private/pubsub.py", line 28, in emit
    s['handler'](self.conn, data)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/user/github/i3-unity-fix/i3unityfix/i3unityfix.py", line 36, in on_workspace_focus
    if event.old.rect.x == event.current.rect.x:
       ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'rect'
```

This patch fixes the issue